### PR TITLE
Migrate GitHub Actions to Blacksmith runners

### DIFF
--- a/.github/workflows/backward-compatibility.yml
+++ b/.github/workflows/backward-compatibility.yml
@@ -15,7 +15,7 @@ jobs:
   backward-compatibility:
     name: "Backward Compatibility"
 
-    runs-on: "ubuntu-latest"
+    runs-on: blacksmith-4vcpu-ubuntu-2404
     timeout-minutes: 30
 
     steps:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,7 +14,7 @@ env:
 jobs:
   lint:
     name: "Lint"
-    runs-on: "ubuntu-latest"
+    runs-on: blacksmith-4vcpu-ubuntu-2404
     if: ${{ false }}
 
     strategy:
@@ -52,7 +52,7 @@ jobs:
   coding-standards:
     name: "Coding Standard"
 
-    runs-on: "ubuntu-latest"
+    runs-on: blacksmith-4vcpu-ubuntu-2404
     if: ${{ false }}
 
     strategy:
@@ -85,7 +85,7 @@ jobs:
   dependency-analysis:
     name: "Dependency Analysis"
 
-    runs-on: "ubuntu-latest"
+    runs-on: blacksmith-4vcpu-ubuntu-2404
     if: ${{ false }}
 
     strategy:
@@ -195,7 +195,7 @@ jobs:
   tests-code-coverage:
     name: "Tests with code coverage"
 
-    runs-on: "ubuntu-latest"
+    runs-on: blacksmith-4vcpu-ubuntu-2404
 
     steps:
       - name: "Checkout"
@@ -280,7 +280,7 @@ jobs:
     name: "PHPStan with result cache"
     if: ${{ false }}
 
-    runs-on: ubuntu-latest
+    runs-on: blacksmith-4vcpu-ubuntu-2404
 
     strategy:
       matrix:
@@ -357,7 +357,7 @@ jobs:
     name: "Compiler Tests"
     if: ${{ false }}
 
-    runs-on: "ubuntu-latest"
+    runs-on: blacksmith-4vcpu-ubuntu-2404
 
     steps:
       - name: "Checkout"
@@ -388,7 +388,7 @@ jobs:
     name: "Generate baseline"
     if: ${{ false }}
 
-    runs-on: "ubuntu-latest"
+    runs-on: blacksmith-4vcpu-ubuntu-2404
 
     strategy:
       matrix:
@@ -416,7 +416,7 @@ jobs:
 
   e2e-tests:
     name: "E2E tests"
-    runs-on: "ubuntu-latest"
+    runs-on: blacksmith-4vcpu-ubuntu-2404
     if: ${{ false }}
 
     strategy:

--- a/.github/workflows/compiler-tests.yml
+++ b/.github/workflows/compiler-tests.yml
@@ -15,7 +15,7 @@ jobs:
   compiler-tests:
     name: "Compiler Tests"
 
-    runs-on: "ubuntu-latest"
+    runs-on: blacksmith-4vcpu-ubuntu-2404
     timeout-minutes: 30
 
     steps:

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -46,7 +46,7 @@ jobs:
 
   e2e-tests:
     name: "E2E tests"
-    runs-on: "ubuntu-latest"
+    runs-on: blacksmith-4vcpu-ubuntu-2404
     timeout-minutes: 30
 
     strategy:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -14,7 +14,7 @@ env:
 jobs:
   lint:
     name: "Lint"
-    runs-on: "ubuntu-latest"
+    runs-on: blacksmith-4vcpu-ubuntu-2404
     timeout-minutes: 30
 
     strategy:
@@ -53,7 +53,7 @@ jobs:
   coding-standards:
     name: "Coding Standard"
 
-    runs-on: "ubuntu-latest"
+    runs-on: blacksmith-4vcpu-ubuntu-2404
     timeout-minutes: 30
 
     strategy:
@@ -86,7 +86,7 @@ jobs:
   dependency-analysis:
     name: "Dependency Analysis"
 
-    runs-on: "ubuntu-latest"
+    runs-on: blacksmith-4vcpu-ubuntu-2404
     timeout-minutes: 30
 
     strategy:

--- a/.github/workflows/phar-old.yml
+++ b/.github/workflows/phar-old.yml
@@ -12,7 +12,7 @@ concurrency: phar
 jobs:
   compile:
     name: "Compile PHAR"
-    runs-on: "ubuntu-latest"
+    runs-on: blacksmith-4vcpu-ubuntu-2404
     timeout-minutes: 30
 
     steps:

--- a/.github/workflows/phar.yml
+++ b/.github/workflows/phar.yml
@@ -14,7 +14,7 @@ concurrency: phar
 jobs:
   compile:
     name: "Compile PHAR"
-    runs-on: "ubuntu-latest"
+    runs-on: blacksmith-4vcpu-ubuntu-2404
     timeout-minutes: 30
 
     steps:

--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -60,7 +60,7 @@ jobs:
   static-analysis-with-result-cache:
     name: "PHPStan with result cache"
 
-    runs-on: "ubuntu-latest"
+    runs-on: blacksmith-4vcpu-ubuntu-2404
     timeout-minutes: 30
 
     strategy:
@@ -106,7 +106,7 @@ jobs:
   generate-baseline:
     name: "Generate baseline"
 
-    runs-on: "ubuntu-latest"
+    runs-on: blacksmith-4vcpu-ubuntu-2404
     timeout-minutes: 30
 
     strategy:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -98,7 +98,7 @@ jobs:
   tests-code-coverage:
     name: "Tests with code coverage"
 
-    runs-on: "ubuntu-latest"
+    runs-on: blacksmith-4vcpu-ubuntu-2404
     timeout-minutes: 30
 
     steps:


### PR DESCRIPTION
## Summary
- Migrate GitHub Actions workflows from GitHub-hosted runners to Blacksmith runners
- Delete unused/deprecated workflow files where applicable
- Heavy workflows (builds, tests, Docker) use `blacksmith-4vcpu-ubuntu-2404`
- Light workflows (dispatch, lint, sync) use `blacksmith-2vcpu-ubuntu-2404`
- macOS, Windows, and self-hosted runners are left unchanged

## Related
- ENG-4173 (Blacksmith migration)
- ENG-4174 (Workflow cleanup)